### PR TITLE
feat(fleet-tools): add update_inventory tool + suggest_targets upgrade notifications (#75)

### DIFF
--- a/src/server/services/fleet-tools/declarations.ts
+++ b/src/server/services/fleet-tools/declarations.ts
@@ -836,6 +836,51 @@ export const FLEET_TOOL_DECLARATIONS: FunctionDeclaration[] = [
     },
   },
   {
+    name: "update_inventory",
+    description:
+      "Record the Admiral's current resource inventory — ore, gas, crystal, parts, currency, or blueprints. " +
+      "Use this when the Admiral tells you what resources they have " +
+      "(e.g. 'I have 280 3-star Ore and 150 3-star Crystal'). " +
+      "Each item requires a category and name; grade and quantity are optional.",
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        items: {
+          type: Type.ARRAY,
+          description: "Array of inventory items to record.",
+          items: {
+            type: Type.OBJECT,
+            properties: {
+              category: {
+                type: Type.STRING,
+                enum: ["ore", "gas", "crystal", "parts", "currency", "blueprint", "other"],
+                description: "Resource category.",
+              },
+              name: {
+                type: Type.STRING,
+                description: "Resource name, e.g. '3★ Ore', 'Latinum', 'Bortas Blueprints'.",
+              },
+              grade: {
+                type: Type.STRING,
+                description: "Optional grade/rarity, e.g. '3-star', 'rare', 'common'.",
+              },
+              quantity: {
+                type: Type.INTEGER,
+                description: "Amount the Admiral currently has.",
+              },
+            },
+            required: ["category", "name", "quantity"],
+          },
+        },
+        source: {
+          type: Type.STRING,
+          description: "Optional source label, e.g. 'manual', 'chat', 'import'.",
+        },
+      },
+      required: ["items"],
+    },
+  },
+  {
     name: "set_officer_overlay",
     description:
       "Record the Admiral's actual in-game officer progression: current level, rank (1-5), power, " +

--- a/src/server/services/fleet-tools/index.ts
+++ b/src/server/services/fleet-tools/index.ts
@@ -57,6 +57,7 @@ import {
   completeTargetTool,
   setShipOverlayTool,
   setOfficerOverlayTool,
+  updateInventoryTool,
 } from "./mutate-tools.js";
 
 // ─── Dispatcher ─────────────────────────────────────────────
@@ -188,6 +189,8 @@ async function dispatchTool(
       return setShipOverlayTool(args, ctx);
     case "set_officer_overlay":
       return setOfficerOverlayTool(args, ctx);
+    case "update_inventory":
+      return updateInventoryTool(args, ctx);
     default:
       return { error: `Unknown tool: ${name}` };
   }


### PR DESCRIPTION
## Summary

Implements the two remaining standalone slices from **#75 Inventory Phase 3**:

### `update_inventory` mutation tool
Manual chat entry for inventory ("I have 280 3-star Ore"):
- Accepts `items[]` array with category, name, grade, quantity
- Validates category enum, name, quantity (non-negative)
- Partial success: valid items upserted, invalid items returned as `warnings`
- Source defaults to `"chat"`, supports `"translator"` etc.
- Full AX-friendly response: `tool`, `recorded`, `upserted`, `categories`, `items`, `nextSteps`

### `suggest_targets` — "Ready to Upgrade" notifications
Enhanced to check owned ships against current inventory:
- For each owned ship, computes next-tier resource requirements
- Compares against inventory using `normalizeToken()` fuzzy matching
- Ships with ≥80% resource coverage are surfaced as `readyToUpgrade`
- Sorted by coverage, capped at 10, wrapped in try/catch for graceful degradation

### Test Coverage
- 13 new tests (188 total fleet-tools tests)
- `update_inventory`: happy path, partial success, all-invalid, empty array, non-array, store unavailable, negative quantity, zero quantity, custom source
- `suggest_targets` upgrade: ≥80% coverage shown, <80% omitted, graceful degradation
- Declaration assertion for `update_inventory`

### Validation
- ✅ TypeScript: `tsc --noEmit` clean
- ✅ Server: 1,374 tests pass (42 files)
- ✅ Web: 174 tests pass (13 files)
- ✅ Lint: clean
- ✅ Build: clean

### Files Changed
- `src/server/services/fleet-tools/declarations.ts` — `update_inventory` declaration
- `src/server/services/fleet-tools/mutate-tools.ts` — `updateInventoryTool` handler
- `src/server/services/fleet-tools/index.ts` — dispatcher wiring
- `src/server/services/fleet-tools/read-tools.ts` — `suggestTargets` "Ready to Upgrade" block
- `test/fleet-tools.test.ts` — 13 new tests

### Remaining #75 items (blocked)
- [ ] Advanced import via Translator — depends on #78
- [ ] High-impact apply path — depends on #93

Closes partial #75