### PR TITLE
feat: External Overlay Translator (#78)

### DIFF
--- a/data/translators/stfc-command-center-v1.translator.json
+++ b/data/translators/stfc-command-center-v1.translator.json
@@ -1,0 +1,57 @@
+{
+  "name": "STFC Command Center Export",
+  "version": "1.0",
+  "description": "Translates user fleet data exported from STFC Command Center (community tool). Maps player-owned officer levels, ship tiers, and dock assignments into MajelGameExport format.",
+  "sourceType": "command-center",
+  "officers": {
+    "sourcePath": "officers",
+    "idField": "id",
+    "idPrefix": "cdn:officer:",
+    "fieldMap": {
+      "level": "level",
+      "rank": "rank",
+      "tier": "tier",
+      "power": "power",
+      "owned": "owned"
+    },
+    "defaults": {
+      "owned": true
+    },
+    "transforms": {
+      "rank": { "type": "toString" },
+      "level": { "type": "toNumber" },
+      "tier": { "type": "toNumber" },
+      "power": { "type": "toNumber" }
+    }
+  },
+  "ships": {
+    "sourcePath": "ships",
+    "idField": "id",
+    "idPrefix": "cdn:ship:",
+    "fieldMap": {
+      "tier": "tier",
+      "level": "level",
+      "power": "power",
+      "owned": "owned"
+    },
+    "defaults": {
+      "owned": true
+    },
+    "transforms": {
+      "tier": { "type": "toNumber" },
+      "level": { "type": "toNumber" },
+      "power": { "type": "toNumber" }
+    }
+  },
+  "docks": {
+    "sourcePath": "docks",
+    "fieldMap": {
+      "slot": "number",
+      "ship_id": "shipId"
+    },
+    "shipIdPrefix": "cdn:ship:",
+    "transforms": {
+      "number": { "type": "toNumber" }
+    }
+  }
+}

--- a/docs/ADR-028-data-pipeline-roadmap.md
+++ b/docs/ADR-028-data-pipeline-roadmap.md
@@ -18,7 +18,8 @@
 | Phase 3: Inventory | — | Not started | Resource planning |
 | Phase 4: Events/Away Teams | — | Not started | Dynamic game state |
 | Phase 5: Battle Logs | — | Not started | Combat analysis |
-| Cross-Cutting: Safe Mutation Path | #93 | Planned | Confirmation-gated proposal/apply for agent-driven writes |
+| Cross-Cutting: Safe Mutation Path | #93 | ✅ Complete | Confirmation-gated proposal/apply for agent-driven writes (PR #118) |
+| Cross-Cutting: Translator | #78 | ✅ Complete | Config-driven external data → MajelGameExport mapping (PR #119) |
 
 ## Context
 

--- a/schemas/translator-config.schema.json
+++ b/schemas/translator-config.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://majel.dev/schemas/translator-config.schema.json",
+  "title": "TranslatorConfig",
+  "description": "Configuration for translating an external game data source into MajelGameExport format. Each .translator.json file maps one external source — no code changes needed to add new sources.",
+  "type": "object",
+  "required": ["name", "version", "sourceType"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for this translator (e.g. 'Ripper Command Center')."
+    },
+    "version": {
+      "type": "string",
+      "description": "Translator config version (e.g. '1.0'). Used for forward compatibility."
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Optional description of the external source this translator handles."
+    },
+    "sourceType": {
+      "type": "string",
+      "description": "Source identifier used in MajelGameExport.source and receipt tracking (e.g. 'command-center', 'stfc-space')."
+    },
+    "officers": {
+      "$ref": "#/$defs/entityMapping",
+      "description": "Mapping config for officer entities."
+    },
+    "ships": {
+      "$ref": "#/$defs/entityMapping",
+      "description": "Mapping config for ship entities."
+    },
+    "docks": {
+      "$ref": "#/$defs/dockMapping",
+      "description": "Mapping config for dock assignments."
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entityMapping": {
+      "type": "object",
+      "description": "Maps an array of external entity objects to MajelGameExport entities (officers or ships).",
+      "required": ["sourcePath", "idField", "idPrefix", "fieldMap"],
+      "properties": {
+        "sourcePath": {
+          "type": "string",
+          "description": "Dot-notation JSON path to the source array in the external payload (e.g. 'data.officers', 'officers')."
+        },
+        "idField": {
+          "type": "string",
+          "description": "Field name in the source object that holds the entity ID (e.g. 'officer_id', 'ship_id')."
+        },
+        "idPrefix": {
+          "type": "string",
+          "description": "Majel refId prefix prepended to the source ID (e.g. 'cdn:officer:', 'cdn:ship:')."
+        },
+        "fieldMap": {
+          "type": "object",
+          "description": "Maps source field names to MajelGameExport field names (e.g. { \"lvl\": \"level\", \"rnk\": \"rank\" }).",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "defaults": {
+          "type": "object",
+          "description": "Default values for fields not present in the source data (e.g. { \"owned\": true }).",
+          "additionalProperties": true
+        },
+        "transforms": {
+          "type": "object",
+          "description": "Per-field transform rules keyed by target field name.",
+          "additionalProperties": {
+            "$ref": "#/$defs/fieldTransform"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "dockMapping": {
+      "type": "object",
+      "description": "Maps external dock/slot data to MajelGameExport dock assignments. Docks use number + shipId rather than a refId.",
+      "required": ["sourcePath", "fieldMap"],
+      "properties": {
+        "sourcePath": {
+          "type": "string",
+          "description": "Dot-notation JSON path to the source array in the external payload (e.g. 'data.docks', 'docks')."
+        },
+        "fieldMap": {
+          "type": "object",
+          "description": "Maps source field names to MajelGameExport dock field names (e.g. { \"slot\": \"number\", \"ship_ref\": \"shipId\" }).",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "shipIdPrefix": {
+          "type": ["string", "null"],
+          "description": "Optional prefix for shipId values (e.g. 'cdn:ship:'). Applied to the mapped shipId field."
+        },
+        "defaults": {
+          "type": "object",
+          "description": "Default values for fields not present in the source data.",
+          "additionalProperties": true
+        },
+        "transforms": {
+          "type": "object",
+          "description": "Per-field transform rules keyed by target field name.",
+          "additionalProperties": {
+            "$ref": "#/$defs/fieldTransform"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "fieldTransform": {
+      "type": "object",
+      "description": "A transform rule applied to a single field value during translation.",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["lookup", "toString", "toNumber", "toBoolean"],
+          "description": "Transform type. 'lookup' maps discrete values via a table. 'toString', 'toNumber', 'toBoolean' coerce the value."
+        },
+        "table": {
+          "type": "object",
+          "description": "Lookup table for 'lookup' transforms. Keys are source values (as strings), values are target values.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -84,6 +84,7 @@ import { createCrewRoutes } from "./routes/crews.js";
 import { createReceiptRoutes } from "./routes/receipts.js";
 import { createImportRoutes } from "./routes/imports.js";
 import { createProposalRoutes } from "./routes/proposals.js";
+import { createTranslatorRoutes } from "./routes/translator.js";
 
 // Re-export for test compatibility
 export type { AppState };
@@ -278,6 +279,7 @@ export function createApp(appState: AppState): express.Express {
   app.use(createReceiptRoutes(appState));
   app.use(createImportRoutes(appState));
   app.use(createProposalRoutes(appState));
+  app.use(createTranslatorRoutes(appState));
 
   // ─── SPA Fallback (authenticated app) ─────────────────────
   app.get("/app/{*splat}", (_req, res) => {

--- a/src/server/routes/translator.ts
+++ b/src/server/routes/translator.ts
@@ -1,0 +1,111 @@
+/**
+ * translator.ts — External Overlay Translator API Routes (#78 Phase 4)
+ *
+ * Majel — STFC Fleet Intelligence System
+ *
+ * Provides endpoints to list translator configs, preview translations,
+ * and translate + apply external game data via the sync_overlay pipeline.
+ *
+ * Pattern: factory function createTranslatorRoutes(appState) → Router
+ */
+
+import { join } from "node:path";
+import type { Router } from "express";
+import type { AppState } from "../app-context.js";
+import { sendOk, sendFail, ErrorCode } from "../envelope.js";
+import { requireVisitor } from "../services/auth.js";
+import { createSafeRouter } from "../safe-router.js";
+import { listTranslatorConfigs, loadTranslatorConfig, translate } from "../services/translator/index.js";
+import { executeFleetTool } from "../services/fleet-tools/index.js";
+
+/** Characters forbidden in configName to prevent path traversal. */
+const UNSAFE_CONFIG_RE = /[./\\]/;
+
+export function createTranslatorRoutes(appState: AppState): Router {
+  const router = createSafeRouter();
+  const visitor = requireVisitor(appState);
+  router.use("/api/translate", visitor);
+
+  // ── List available translator configs ─────────────────────
+
+  router.get("/api/translate/configs", async (_req, res) => {
+    const configDir = join(process.cwd(), "data", "translators");
+    const configs = await listTranslatorConfigs(configDir);
+    sendOk(res, { configs });
+  });
+
+  // ── Preview translation (dry-run, no apply) ───────────────
+
+  router.post("/api/translate/preview", async (req, res) => {
+    const { configName, payload } = req.body ?? {};
+
+    if (typeof configName !== "string" || configName.length === 0) {
+      return sendFail(res, ErrorCode.MISSING_PARAM, "configName is required", 400);
+    }
+    if (UNSAFE_CONFIG_RE.test(configName)) {
+      return sendFail(res, ErrorCode.INVALID_PARAM, "configName contains invalid characters", 400);
+    }
+    if (payload === undefined || payload === null || typeof payload !== "object") {
+      return sendFail(res, ErrorCode.MISSING_PARAM, "payload must be a non-null object", 400);
+    }
+
+    const configPath = join(process.cwd(), "data", "translators", `${configName}.translator.json`);
+
+    try {
+      const config = await loadTranslatorConfig(configPath);
+      const result = translate(config, payload);
+      return sendOk(res, result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return sendFail(res, ErrorCode.INVALID_PARAM, `Translation failed: ${msg}`, 400);
+    }
+  });
+
+  // ── Translate + apply via sync_overlay ─────────────────────
+
+  router.post("/api/translate/apply", async (req, res) => {
+    const { configName, payload, dry_run } = req.body ?? {};
+
+    if (typeof configName !== "string" || configName.length === 0) {
+      return sendFail(res, ErrorCode.MISSING_PARAM, "configName is required", 400);
+    }
+    if (UNSAFE_CONFIG_RE.test(configName)) {
+      return sendFail(res, ErrorCode.INVALID_PARAM, "configName contains invalid characters", 400);
+    }
+    if (payload === undefined || payload === null || typeof payload !== "object") {
+      return sendFail(res, ErrorCode.MISSING_PARAM, "payload must be a non-null object", 400);
+    }
+
+    const configPath = join(process.cwd(), "data", "translators", `${configName}.translator.json`);
+
+    let config;
+    try {
+      config = await loadTranslatorConfig(configPath);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return sendFail(res, ErrorCode.INVALID_PARAM, `Failed to load translator config: ${msg}`, 400);
+    }
+
+    const result = translate(config, payload);
+    if (!result.success || !result.data) {
+      return sendOk(res, { translation: result, sync: null });
+    }
+
+    // Build tool context for sync_overlay execution
+    const userId = res.locals.userId as string;
+    if (!appState.toolContextFactory) {
+      return sendFail(res, ErrorCode.INTERNAL_ERROR, "Tool context factory not available", 503);
+    }
+    const toolContext = appState.toolContextFactory.forUser(userId);
+
+    const syncResult = await executeFleetTool(
+      "sync_overlay",
+      { export: result.data, dry_run: dry_run ?? true },
+      toolContext,
+    );
+
+    sendOk(res, { translation: result, sync: syncResult });
+  });
+
+  return router;
+}

--- a/src/server/services/translator/index.ts
+++ b/src/server/services/translator/index.ts
@@ -1,0 +1,8 @@
+/**
+ * translator/index.ts — Barrel re-export for External Overlay Translator (#78)
+ *
+ * Majel — STFC Fleet Intelligence System
+ */
+
+export * from "./types.js";
+export * from "./translate.js";

--- a/src/server/services/translator/translate.ts
+++ b/src/server/services/translator/translate.ts
@@ -1,0 +1,393 @@
+/**
+ * translator/translate.ts — Core Translation Engine (#78, Phase 2)
+ *
+ * Majel — STFC Fleet Intelligence System
+ *
+ * Config-driven translation of external game data into MajelGameExport
+ * format. Each external source is described by a `.translator.json` config
+ * file; no code changes are required to add new sources.
+ *
+ * The translator performs faithful field mapping, defaults, and type
+ * coercion. It does NOT apply MajelGameExport validation rules — that
+ * happens downstream when sync_overlay receives the translated data.
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { rootLogger } from "../../logger.js";
+import type {
+  TranslatorConfig,
+  EntityMapping,
+  DockMapping,
+  FieldTransform,
+  TranslationResult,
+  TranslationStats,
+} from "./types.js";
+
+const log = rootLogger.child({ subsystem: "translator" });
+
+// ─── Path Traversal ─────────────────────────────────────────
+
+/**
+ * Resolve a dot-notation path against a payload object.
+ *
+ * @param payload - The root object to traverse.
+ * @param path - Dot-delimited path (e.g. "data.officers").
+ * @returns The value at the path, or `undefined` if any segment is missing.
+ */
+export function resolveSourcePath(payload: unknown, path: string): unknown {
+  const segments = path.split(".");
+  let current: unknown = payload;
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+// ─── Transforms ─────────────────────────────────────────────
+
+/**
+ * Apply a single transform to a field value.
+ *
+ * - `lookup`: maps `String(value)` through `transform.table`; returns the
+ *   original value if the key is not found.
+ * - `toString`: coerces to string via `String()`.
+ * - `toNumber`: coerces via `Number()`; returns `null` if the result is NaN.
+ * - `toBoolean`: truthy coercion with special string handling —
+ *   `"true"/"1"/"yes"` → `true`, `"false"/"0"/"no"/""` → `false`.
+ *
+ * @param value - The raw field value.
+ * @param transform - The transform descriptor.
+ * @returns The transformed value.
+ */
+export function applyTransform(value: unknown, transform: FieldTransform): unknown {
+  switch (transform.type) {
+    case "lookup": {
+      const key = String(value);
+      if (transform.table && key in transform.table) {
+        return transform.table[key];
+      }
+      return value;
+    }
+    case "toString":
+      return String(value);
+    case "toNumber": {
+      const num = Number(value);
+      return Number.isNaN(num) ? null : num;
+    }
+    case "toBoolean": {
+      if (typeof value === "string") {
+        const lower = value.toLowerCase().trim();
+        if (lower === "true" || lower === "1" || lower === "yes") return true;
+        if (lower === "false" || lower === "0" || lower === "no" || lower === "") return false;
+      }
+      return Boolean(value);
+    }
+    default:
+      return value;
+  }
+}
+
+// ─── Config Loading ─────────────────────────────────────────
+
+/**
+ * Load and validate a translator config from a `.translator.json` file.
+ *
+ * @param configPath - Absolute or relative path to the config file.
+ * @returns The parsed `TranslatorConfig`.
+ * @throws If the file cannot be read or required fields are missing.
+ */
+export async function loadTranslatorConfig(configPath: string): Promise<TranslatorConfig> {
+  let raw: string;
+  try {
+    raw = await readFile(configPath, "utf-8");
+  } catch (err) {
+    throw new Error(`Failed to read translator config at ${configPath}: ${(err as Error).message}`, { cause: err });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in translator config at ${configPath}`);
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Translator config at ${configPath} must be a JSON object`);
+  }
+
+  const config = parsed as Record<string, unknown>;
+
+  if (typeof config.name !== "string" || !config.name) {
+    throw new Error(`Translator config at ${configPath} is missing required field 'name'`);
+  }
+  if (typeof config.version !== "string" || !config.version) {
+    throw new Error(`Translator config at ${configPath} is missing required field 'version'`);
+  }
+  if (typeof config.sourceType !== "string" || !config.sourceType) {
+    throw new Error(`Translator config at ${configPath} is missing required field 'sourceType'`);
+  }
+
+  log.debug({ path: configPath, name: config.name }, "loaded translator config");
+  return config as unknown as TranslatorConfig;
+}
+
+/**
+ * List available translator configs in a directory.
+ *
+ * Scans for `*.translator.json` files and returns lightweight metadata
+ * without fully loading each config.
+ *
+ * @param configDir - Directory to scan.
+ * @returns Array of config summaries with path, name, sourceType, and description.
+ */
+export async function listTranslatorConfigs(
+  configDir: string,
+): Promise<Array<{ name: string; sourceType: string; description?: string | null; path: string }>> {
+  let entries: string[];
+  try {
+    entries = await readdir(configDir);
+  } catch {
+    log.warn({ configDir }, "translator config directory not found");
+    return [];
+  }
+
+  const configFiles = entries.filter((f) => f.endsWith(".translator.json"));
+  const results: Array<{ name: string; sourceType: string; description?: string | null; path: string }> = [];
+
+  for (const file of configFiles) {
+    const filePath = join(configDir, file);
+    try {
+      const raw = await readFile(filePath, "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof parsed.name === "string" && typeof parsed.sourceType === "string") {
+        results.push({
+          name: parsed.name as string,
+          sourceType: parsed.sourceType as string,
+          description: typeof parsed.description === "string" ? parsed.description : (parsed.description as string | null | undefined) ?? null,
+          path: filePath,
+        });
+      }
+    } catch {
+      log.warn({ file: filePath }, "skipping unreadable translator config");
+    }
+  }
+
+  return results;
+}
+
+// ─── Internal Helpers ───────────────────────────────────────
+
+/** Create a fresh zero-count stats object. */
+function emptyStats(): TranslationStats {
+  return {
+    officers: { translated: 0, skipped: 0, errored: 0 },
+    ships: { translated: 0, skipped: 0, errored: 0 },
+    docks: { translated: 0, skipped: 0, errored: 0 },
+  };
+}
+
+/**
+ * Map fields from a source item to a target item using a fieldMap,
+ * then layer in defaults and apply transforms.
+ */
+function mapFields(
+  sourceItem: Record<string, unknown>,
+  fieldMap: Record<string, string>,
+  defaults?: Record<string, unknown>,
+  transforms?: Record<string, FieldTransform>,
+): Record<string, unknown> {
+  const target: Record<string, unknown> = {};
+
+  // 1. Map source fields → target fields
+  for (const [sourceKey, targetKey] of Object.entries(fieldMap)) {
+    if (sourceKey in sourceItem) {
+      target[targetKey] = sourceItem[sourceKey];
+    }
+  }
+
+  // 2. Apply defaults for missing target fields
+  if (defaults) {
+    for (const [key, value] of Object.entries(defaults)) {
+      if (!(key in target) || target[key] === undefined || target[key] === null) {
+        target[key] = value;
+      }
+    }
+  }
+
+  // 3. Apply transforms (keyed by target field name)
+  if (transforms) {
+    for (const [targetKey, transform] of Object.entries(transforms)) {
+      if (targetKey in target) {
+        target[targetKey] = applyTransform(target[targetKey], transform);
+      }
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Translate an entity array (officers or ships) using an EntityMapping.
+ */
+function translateEntities(
+  sourceArray: unknown[],
+  mapping: EntityMapping,
+  category: "officers" | "ships",
+  stats: TranslationStats,
+  warnings: string[],
+): Array<Record<string, unknown>> {
+  const output: Array<Record<string, unknown>> = [];
+
+  for (let i = 0; i < sourceArray.length; i++) {
+    const item = sourceArray[i];
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      stats[category].errored++;
+      warnings.push(`${category}[${i}]: skipped — not a valid object`);
+      continue;
+    }
+
+    const sourceItem = item as Record<string, unknown>;
+    const rawId = sourceItem[mapping.idField];
+
+    if (rawId === undefined || rawId === null || rawId === "") {
+      stats[category].errored++;
+      warnings.push(`${category}[${i}]: skipped — missing idField '${mapping.idField}'`);
+      continue;
+    }
+
+    const refId = `${mapping.idPrefix}${String(rawId)}`;
+    const mapped = mapFields(sourceItem, mapping.fieldMap, mapping.defaults, mapping.transforms);
+    mapped.refId = refId;
+
+    output.push(mapped);
+    stats[category].translated++;
+  }
+
+  return output;
+}
+
+/**
+ * Translate a dock array using a DockMapping.
+ */
+function translateDocks(
+  sourceArray: unknown[],
+  mapping: DockMapping,
+  stats: TranslationStats,
+  warnings: string[],
+): Array<Record<string, unknown>> {
+  const output: Array<Record<string, unknown>> = [];
+
+  for (let i = 0; i < sourceArray.length; i++) {
+    const item = sourceArray[i];
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      stats.docks.errored++;
+      warnings.push(`docks[${i}]: skipped — not a valid object`);
+      continue;
+    }
+
+    const sourceItem = item as Record<string, unknown>;
+    const mapped = mapFields(sourceItem, mapping.fieldMap, mapping.defaults, mapping.transforms);
+
+    // Apply shipIdPrefix if provided
+    if (mapping.shipIdPrefix && typeof mapped.shipId === "string" && mapped.shipId) {
+      mapped.shipId = `${mapping.shipIdPrefix}${mapped.shipId}`;
+    }
+
+    output.push(mapped);
+    stats.docks.translated++;
+  }
+
+  return output;
+}
+
+// ─── Core Translation ───────────────────────────────────────
+
+/**
+ * Translate an external game data payload into MajelGameExport format
+ * using the provided translator config.
+ *
+ * The translator faithfully maps fields, applies defaults and transforms,
+ * but does NOT validate the output against MajelGameExport rules —
+ * downstream consumers (sync_overlay) handle that.
+ *
+ * @param config - The translator configuration.
+ * @param externalPayload - Raw external data (parsed JSON).
+ * @returns A `TranslationResult` with translated data, stats, and warnings.
+ */
+export function translate(config: TranslatorConfig, externalPayload: unknown): TranslationResult {
+  const stats = emptyStats();
+  const warnings: string[] = [];
+
+  // Validate payload is a non-null object
+  if (externalPayload === null || externalPayload === undefined || typeof externalPayload !== "object" || Array.isArray(externalPayload)) {
+    log.warn({ sourceType: config.sourceType }, "translate: payload is not a valid object");
+    return {
+      success: false,
+      data: null,
+      stats,
+      warnings: ["payload must be a non-null object"],
+    };
+  }
+
+  const data: NonNullable<TranslationResult["data"]> = {
+    version: "1.0",
+    exportDate: new Date().toISOString(),
+    source: config.sourceType,
+  };
+
+  // ── Officers ──────────────────────────────────────────────
+  if (config.officers) {
+    const resolved = resolveSourcePath(externalPayload, config.officers.sourcePath);
+    if (!Array.isArray(resolved)) {
+      warnings.push(`officers: sourcePath '${config.officers.sourcePath}' did not resolve to an array`);
+    } else {
+      data.officers = translateEntities(resolved, config.officers, "officers", stats, warnings) as NonNullable<TranslationResult["data"]>["officers"];
+    }
+  }
+
+  // ── Ships ─────────────────────────────────────────────────
+  if (config.ships) {
+    const resolved = resolveSourcePath(externalPayload, config.ships.sourcePath);
+    if (!Array.isArray(resolved)) {
+      warnings.push(`ships: sourcePath '${config.ships.sourcePath}' did not resolve to an array`);
+    } else {
+      data.ships = translateEntities(resolved, config.ships, "ships", stats, warnings) as NonNullable<TranslationResult["data"]>["ships"];
+    }
+  }
+
+  // ── Docks ─────────────────────────────────────────────────
+  if (config.docks) {
+    const resolved = resolveSourcePath(externalPayload, config.docks.sourcePath);
+    if (!Array.isArray(resolved)) {
+      warnings.push(`docks: sourcePath '${config.docks.sourcePath}' did not resolve to an array`);
+    } else {
+      data.docks = translateDocks(resolved, config.docks, stats, warnings) as NonNullable<TranslationResult["data"]>["docks"];
+    }
+  }
+
+  // Success if at least one entity was translated
+  const totalTranslated = stats.officers.translated + stats.ships.translated + stats.docks.translated;
+  const success = totalTranslated > 0;
+
+  if (!success) {
+    warnings.push("no entities were successfully translated");
+  }
+
+  log.info(
+    {
+      sourceType: config.sourceType,
+      success,
+      officers: stats.officers.translated,
+      ships: stats.ships.translated,
+      docks: stats.docks.translated,
+      warnings: warnings.length,
+    },
+    "translation complete",
+  );
+
+  return { success, data, stats, warnings };
+}

--- a/src/server/services/translator/types.ts
+++ b/src/server/services/translator/types.ts
@@ -1,0 +1,121 @@
+/**
+ * translator/types.ts — External Overlay Translator types (#78)
+ *
+ * Majel — STFC Fleet Intelligence System
+ *
+ * TypeScript interfaces for config-driven translation of external game data
+ * into MajelGameExport format. Adding a new external source requires only
+ * a new .translator.json file — no code changes.
+ *
+ * Matches: schemas/translator-config.schema.json
+ */
+
+// ─── Transform Types ────────────────────────────────────────
+
+/** Allowed transform operations applied to individual field values. */
+export type TransformType = "lookup" | "toString" | "toNumber" | "toBoolean";
+
+/** A transform rule applied to a single field value during translation. */
+export interface FieldTransform {
+  /** Transform type. 'lookup' maps via a table; others coerce the value. */
+  type: TransformType;
+  /** Lookup table for 'lookup' transforms. Keys are source values (as strings). */
+  table?: Record<string, unknown>;
+}
+
+// ─── Entity Mappings ────────────────────────────────────────
+
+/** Per-entity-type mapping config (officers or ships). */
+export interface EntityMapping {
+  /** Dot-notation JSON path to the source array (e.g. "data.officers"). */
+  sourcePath: string;
+  /** Field in the source object that holds the entity ID (e.g. "officer_id"). */
+  idField: string;
+  /** Majel refId prefix prepended to the source ID (e.g. "cdn:officer:"). */
+  idPrefix: string;
+  /** Maps source field names → MajelGameExport field names. */
+  fieldMap: Record<string, string>;
+  /** Default values for fields not present in source data. */
+  defaults?: Record<string, unknown>;
+  /** Per-field transform rules keyed by target field name. */
+  transforms?: Record<string, FieldTransform>;
+}
+
+/** Specialized dock mapping — docks use number + shipId, not a refId. */
+export interface DockMapping {
+  /** Dot-notation JSON path to the source array (e.g. "data.docks"). */
+  sourcePath: string;
+  /** Maps source field names → MajelGameExport dock field names. */
+  fieldMap: Record<string, string>;
+  /** Optional prefix for shipId values (e.g. "cdn:ship:"). */
+  shipIdPrefix?: string | null;
+  /** Default values for fields not present in source data. */
+  defaults?: Record<string, unknown>;
+  /** Per-field transform rules keyed by target field name. */
+  transforms?: Record<string, FieldTransform>;
+}
+
+// ─── Top-Level Config ───────────────────────────────────────
+
+/** Top-level translator configuration — one per external source. */
+export interface TranslatorConfig {
+  /** Human-readable name (e.g. "Ripper Command Center"). */
+  name: string;
+  /** Config version string (e.g. "1.0"). */
+  version: string;
+  /** Optional description of the external source. */
+  description?: string | null;
+  /** Source identifier for MajelGameExport.source and receipt tracking. */
+  sourceType: string;
+  /** Officer entity mapping. */
+  officers?: EntityMapping;
+  /** Ship entity mapping. */
+  ships?: EntityMapping;
+  /** Dock assignment mapping. */
+  docks?: DockMapping;
+}
+
+// ─── Translation Output ─────────────────────────────────────
+
+/** Counts of translated, skipped, and errored items per entity category. */
+export interface TranslationStats {
+  officers: { translated: number; skipped: number; errored: number };
+  ships: { translated: number; skipped: number; errored: number };
+  docks: { translated: number; skipped: number; errored: number };
+}
+
+/** Result of a translation run — translated payload + diagnostics. */
+export interface TranslationResult {
+  /** Whether the translation completed without fatal errors. */
+  success: boolean;
+  /** The translated MajelGameExport payload (null on fatal error). */
+  data: {
+    version: string;
+    exportDate?: string;
+    source?: string;
+    officers?: Array<{
+      refId: string;
+      level?: number | null;
+      rank?: string | null;
+      power?: number | null;
+      owned?: boolean;
+      tier?: number | null;
+    }>;
+    ships?: Array<{
+      refId: string;
+      tier?: number | null;
+      level?: number | null;
+      power?: number | null;
+      owned?: boolean;
+    }>;
+    docks?: Array<{
+      number?: number;
+      shipId?: string;
+      loadoutId?: number;
+    }>;
+  } | null;
+  /** Per-category translation statistics. */
+  stats: TranslationStats;
+  /** Non-fatal warnings encountered during translation. */
+  warnings: string[];
+}

--- a/test/translator-routes.test.ts
+++ b/test/translator-routes.test.ts
@@ -1,0 +1,334 @@
+/**
+ * translator-routes.test.ts — Route integration tests for Translator API (#78 Phase 5)
+ *
+ * Majel — STFC Fleet Intelligence System
+ *
+ * Tests the Express routes for external overlay translation using supertest
+ * against the app factory with mocked translator functions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testRequest } from "./helpers/test-request.js";
+import { createApp } from "../src/server/index.js";
+import { makeState } from "./helpers/make-state.js";
+import type { ToolContextFactory } from "../src/server/services/fleet-tools/declarations.js";
+
+// ─── Mock translator service ────────────────────────────────
+
+vi.mock("../src/server/services/translator/index.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../src/server/services/translator/index.js")>();
+  return {
+    ...mod,
+    listTranslatorConfigs: vi.fn().mockResolvedValue([
+      {
+        name: "STFC Command Center Export",
+        sourceType: "command-center",
+        description: "Translates command center data",
+        path: "/data/translators/stfc-command-center-v1.translator.json",
+      },
+    ]),
+    loadTranslatorConfig: vi.fn().mockResolvedValue({
+      name: "STFC Command Center Export",
+      version: "1.0",
+      sourceType: "command-center",
+      officers: {
+        sourcePath: "officers",
+        idField: "id",
+        idPrefix: "cdn:officer:",
+        fieldMap: { level: "level", rank: "rank" },
+      },
+    }),
+    translate: vi.fn().mockReturnValue({
+      success: true,
+      data: {
+        version: "1.0",
+        exportDate: "2026-02-21T00:00:00.000Z",
+        source: "command-center",
+        officers: [{ refId: "cdn:officer:kirk", level: 50, rank: "Captain" }],
+      },
+      stats: {
+        officers: { translated: 1, skipped: 0, errored: 0 },
+        ships: { translated: 0, skipped: 0, errored: 0 },
+        docks: { translated: 0, skipped: 0, errored: 0 },
+      },
+      warnings: [],
+    }),
+  };
+});
+
+// ─── Mock fleet tools ───────────────────────────────────────
+
+vi.mock("../src/server/services/fleet-tools/index.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../src/server/services/fleet-tools/index.js")>();
+  return {
+    ...mod,
+    executeFleetTool: vi.fn().mockResolvedValue({
+      tool: "sync_overlay",
+      dryRun: true,
+      summary: { officers: { input: 1, changed: 1 }, ships: { input: 0, changed: 0 } },
+      changesPreview: { officers: [], ships: [] },
+      warnings: [],
+    }),
+  };
+});
+
+// Re-import mocked modules so we can adjust per-test
+import {
+  listTranslatorConfigs,
+  loadTranslatorConfig,
+  translate,
+} from "../src/server/services/translator/index.js";
+import { executeFleetTool } from "../src/server/services/fleet-tools/index.js";
+
+const mockedList = vi.mocked(listTranslatorConfigs);
+const mockedLoad = vi.mocked(loadTranslatorConfig);
+const mockedTranslate = vi.mocked(translate);
+const mockedExecute = vi.mocked(executeFleetTool);
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function createMockToolContextFactory(): ToolContextFactory {
+  return {
+    forUser: vi.fn().mockReturnValue({
+      userId: "local",
+      referenceStore: null,
+      overlayStore: null,
+      crewStore: null,
+      targetStore: null,
+      receiptStore: null,
+      researchStore: null,
+      inventoryStore: null,
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Reset default mock return values
+  mockedList.mockResolvedValue([
+    {
+      name: "STFC Command Center Export",
+      sourceType: "command-center",
+      description: "Translates command center data",
+      path: "/data/translators/stfc-command-center-v1.translator.json",
+    },
+  ]);
+  mockedLoad.mockResolvedValue({
+    name: "STFC Command Center Export",
+    version: "1.0",
+    sourceType: "command-center",
+    officers: {
+      sourcePath: "officers",
+      idField: "id",
+      idPrefix: "cdn:officer:",
+      fieldMap: { level: "level", rank: "rank" },
+    },
+  });
+  mockedTranslate.mockReturnValue({
+    success: true,
+    data: {
+      version: "1.0",
+      exportDate: "2026-02-21T00:00:00.000Z",
+      source: "command-center",
+      officers: [{ refId: "cdn:officer:kirk", level: 50, rank: "Captain" }],
+    },
+    stats: {
+      officers: { translated: 1, skipped: 0, errored: 0 },
+      ships: { translated: 0, skipped: 0, errored: 0 },
+      docks: { translated: 0, skipped: 0, errored: 0 },
+    },
+    warnings: [],
+  });
+  mockedExecute.mockResolvedValue({
+    tool: "sync_overlay",
+    dryRun: true,
+    summary: { officers: { input: 1, changed: 1 }, ships: { input: 0, changed: 0 } },
+    changesPreview: { officers: [], ships: [] },
+    warnings: [],
+  });
+});
+
+// ─── GET /api/translate/configs ─────────────────────────────
+
+describe("GET /api/translate/configs", () => {
+  it("returns config list", async () => {
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app).get("/api/translate/configs");
+    expect(res.status).toBe(200);
+    expect(res.body.data.configs).toHaveLength(1);
+    expect(res.body.data.configs[0].name).toBe("STFC Command Center Export");
+    expect(res.body.data.configs[0].sourceType).toBe("command-center");
+  });
+});
+
+// ─── POST /api/translate/preview ────────────────────────────
+
+describe("POST /api/translate/preview", () => {
+  it("returns 400 when configName is missing", async () => {
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/preview")
+      .send({ payload: { officers: [] } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_PARAM");
+  });
+
+  it("returns 400 when configName contains path traversal", async () => {
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/preview")
+      .send({ configName: "../etc/passwd", payload: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PARAM");
+    expect(res.body.error.message).toContain("invalid characters");
+  });
+
+  it("returns 400 when payload is missing", async () => {
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/preview")
+      .send({ configName: "stfc-command-center-v1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_PARAM");
+  });
+
+  it("returns translation result for valid request", async () => {
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/preview")
+      .send({
+        configName: "stfc-command-center-v1",
+        payload: { officers: [{ id: "kirk", level: 50 }] },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.success).toBe(true);
+    expect(res.body.data.data.officers).toHaveLength(1);
+    expect(mockedLoad).toHaveBeenCalledTimes(1);
+    expect(mockedTranslate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when loadTranslatorConfig throws", async () => {
+    mockedLoad.mockRejectedValueOnce(new Error("Config not found"));
+    const state = makeState({ startupComplete: true });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/preview")
+      .send({
+        configName: "nonexistent",
+        payload: { officers: [] },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain("Translation failed");
+  });
+});
+
+// ─── POST /api/translate/apply ──────────────────────────────
+
+describe("POST /api/translate/apply", () => {
+  it("returns translation + sync result for valid request with dry_run", async () => {
+    const tcf = createMockToolContextFactory();
+    const state = makeState({ startupComplete: true, toolContextFactory: tcf });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/apply")
+      .send({
+        configName: "stfc-command-center-v1",
+        payload: { officers: [{ id: "kirk", level: 50 }] },
+        dry_run: true,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.translation.success).toBe(true);
+    expect(res.body.data.sync).toBeDefined();
+    expect(res.body.data.sync.tool).toBe("sync_overlay");
+    expect(mockedExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 when toolContextFactory is not available", async () => {
+    const state = makeState({ startupComplete: true, toolContextFactory: null });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/apply")
+      .send({
+        configName: "stfc-command-center-v1",
+        payload: { officers: [{ id: "kirk", level: 50 }] },
+      });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("INTERNAL_ERROR");
+  });
+
+  it("returns sync=null when translation fails", async () => {
+    mockedTranslate.mockReturnValueOnce({
+      success: false,
+      data: null,
+      stats: {
+        officers: { translated: 0, skipped: 0, errored: 0 },
+        ships: { translated: 0, skipped: 0, errored: 0 },
+        docks: { translated: 0, skipped: 0, errored: 0 },
+      },
+      warnings: ["payload must be a non-null object"],
+    });
+
+    const tcf = createMockToolContextFactory();
+    const state = makeState({ startupComplete: true, toolContextFactory: tcf });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/apply")
+      .send({
+        configName: "stfc-command-center-v1",
+        payload: { officers: [] },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.translation.success).toBe(false);
+    expect(res.body.data.sync).toBeNull();
+    expect(mockedExecute).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when configName is missing", async () => {
+    const tcf = createMockToolContextFactory();
+    const state = makeState({ startupComplete: true, toolContextFactory: tcf });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/apply")
+      .send({ payload: { officers: [] } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_PARAM");
+  });
+
+  it("returns 400 when payload is missing", async () => {
+    const tcf = createMockToolContextFactory();
+    const state = makeState({ startupComplete: true, toolContextFactory: tcf });
+    const app = createApp(state);
+
+    const res = await testRequest(app)
+      .post("/api/translate/apply")
+      .send({ configName: "stfc-command-center-v1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("MISSING_PARAM");
+  });
+});

--- a/test/translator.test.ts
+++ b/test/translator.test.ts
@@ -1,0 +1,360 @@
+/**
+ * translator.test.ts — Unit tests for External Overlay Translator engine (#78 Phase 5)
+ *
+ * Majel — STFC Fleet Intelligence System
+ *
+ * Covers: resolveSourcePath, applyTransform, translate (core engine).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveSourcePath,
+  applyTransform,
+  translate,
+} from "../src/server/services/translator/index.js";
+import type { TranslatorConfig, FieldTransform } from "../src/server/services/translator/index.js";
+
+// ─── resolveSourcePath ──────────────────────────────────────
+
+describe("resolveSourcePath", () => {
+  it("resolves nested dot-notation paths", () => {
+    const payload = { data: { officers: [1, 2, 3] } };
+    expect(resolveSourcePath(payload, "data.officers")).toEqual([1, 2, 3]);
+  });
+
+  it("returns undefined for missing intermediate segment", () => {
+    const payload = { data: { officers: [1] } };
+    expect(resolveSourcePath(payload, "data.ships")).toBeUndefined();
+  });
+
+  it("returns undefined when traversing through null", () => {
+    const payload = { data: null };
+    expect(resolveSourcePath(payload, "data.officers")).toBeUndefined();
+  });
+
+  it("returns undefined when traversing through a primitive", () => {
+    const payload = { data: 42 };
+    expect(resolveSourcePath(payload, "data.officers")).toBeUndefined();
+  });
+
+  it("resolves top-level key with single segment", () => {
+    const payload = { officers: ["a"] };
+    expect(resolveSourcePath(payload, "officers")).toEqual(["a"]);
+  });
+
+  it("returns undefined for empty string path segment against root", () => {
+    const payload = { "": "hidden" };
+    // split("") on "" gives [""], which matches the "" key
+    expect(resolveSourcePath(payload, "")).toBe("hidden");
+  });
+
+  it("handles undefined payload", () => {
+    expect(resolveSourcePath(undefined, "a.b")).toBeUndefined();
+  });
+
+  it("handles null payload", () => {
+    expect(resolveSourcePath(null, "a.b")).toBeUndefined();
+  });
+});
+
+// ─── applyTransform ─────────────────────────────────────────
+
+describe("applyTransform", () => {
+  describe("lookup", () => {
+    it("maps through table when key exists", () => {
+      const transform: FieldTransform = {
+        type: "lookup",
+        table: { "1": "Ensign", "2": "Lieutenant" },
+      };
+      expect(applyTransform(1, transform)).toBe("Ensign");
+    });
+
+    it("returns original value when key not in table", () => {
+      const transform: FieldTransform = {
+        type: "lookup",
+        table: { "1": "Ensign" },
+      };
+      expect(applyTransform(99, transform)).toBe(99);
+    });
+
+    it("returns original value when table is undefined", () => {
+      const transform: FieldTransform = { type: "lookup" };
+      expect(applyTransform("hello", transform)).toBe("hello");
+    });
+  });
+
+  describe("toString", () => {
+    it("coerces number to string", () => {
+      expect(applyTransform(42, { type: "toString" })).toBe("42");
+    });
+
+    it("coerces boolean to string", () => {
+      expect(applyTransform(true, { type: "toString" })).toBe("true");
+    });
+
+    it("coerces null to string", () => {
+      expect(applyTransform(null, { type: "toString" })).toBe("null");
+    });
+  });
+
+  describe("toNumber", () => {
+    it("coerces numeric string to number", () => {
+      expect(applyTransform("42", { type: "toNumber" })).toBe(42);
+    });
+
+    it("returns null for non-numeric string (NaN)", () => {
+      expect(applyTransform("abc", { type: "toNumber" })).toBeNull();
+    });
+
+    it("coerces boolean to number", () => {
+      expect(applyTransform(true, { type: "toNumber" })).toBe(1);
+    });
+  });
+
+  describe("toBoolean", () => {
+    it("converts 'true' string → true", () => {
+      expect(applyTransform("true", { type: "toBoolean" })).toBe(true);
+    });
+
+    it("converts 'yes' string → true", () => {
+      expect(applyTransform("yes", { type: "toBoolean" })).toBe(true);
+    });
+
+    it("converts '1' string → true", () => {
+      expect(applyTransform("1", { type: "toBoolean" })).toBe(true);
+    });
+
+    it("converts 'false' string → false", () => {
+      expect(applyTransform("false", { type: "toBoolean" })).toBe(false);
+    });
+
+    it("converts '0' string → false", () => {
+      expect(applyTransform("0", { type: "toBoolean" })).toBe(false);
+    });
+
+    it("converts 'no' string → false", () => {
+      expect(applyTransform("no", { type: "toBoolean" })).toBe(false);
+    });
+
+    it("converts empty string → false", () => {
+      expect(applyTransform("", { type: "toBoolean" })).toBe(false);
+    });
+
+    it("falls back to Boolean() for non-string truthy value", () => {
+      expect(applyTransform(1, { type: "toBoolean" })).toBe(true);
+    });
+
+    it("falls back to Boolean() for non-string falsy value", () => {
+      expect(applyTransform(0, { type: "toBoolean" })).toBe(false);
+    });
+  });
+});
+
+// ─── translate ──────────────────────────────────────────────
+
+/** Minimal config: officers + ships, no docks. */
+const BASE_CONFIG: TranslatorConfig = {
+  name: "Test Translator",
+  version: "1.0",
+  sourceType: "test-source",
+  officers: {
+    sourcePath: "officers",
+    idField: "id",
+    idPrefix: "test:officer:",
+    fieldMap: {
+      level: "level",
+      rank: "rank",
+      power: "power",
+    },
+    defaults: { owned: true },
+    transforms: {
+      level: { type: "toNumber" },
+    },
+  },
+  ships: {
+    sourcePath: "ships",
+    idField: "id",
+    idPrefix: "test:ship:",
+    fieldMap: {
+      tier: "tier",
+      level: "level",
+    },
+  },
+};
+
+describe("translate", () => {
+  it("translates valid payload with officers + ships", () => {
+    const payload = {
+      officers: [
+        { id: "kirk", level: "50", rank: "Captain", power: 9000 },
+        { id: "spock", level: "45", rank: "Commander", power: 8500 },
+      ],
+      ships: [{ id: "enterprise", tier: 8, level: 40 }],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+
+    expect(result.success).toBe(true);
+    expect(result.data).not.toBeNull();
+    expect(result.data!.version).toBe("1.0");
+    expect(result.data!.source).toBe("test-source");
+    expect(result.data!.officers).toHaveLength(2);
+    expect(result.data!.ships).toHaveLength(1);
+    expect(result.stats.officers.translated).toBe(2);
+    expect(result.stats.ships.translated).toBe(1);
+  });
+
+  it("sets correct refId with prefix + source id", () => {
+    const payload = {
+      officers: [{ id: "kirk", level: "50", rank: "Captain", power: 9000 }],
+      ships: [{ id: "ent", tier: 8, level: 40 }],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    expect(result.data!.officers![0].refId).toBe("test:officer:kirk");
+    expect(result.data!.ships![0].refId).toBe("test:ship:ent");
+  });
+
+  it("generates warning when sourcePath does not resolve to an array", () => {
+    const payload = { officers: "not-an-array", ships: [] };
+    const result = translate(BASE_CONFIG, payload);
+
+    expect(result.warnings).toContain(
+      "officers: sourcePath 'officers' did not resolve to an array",
+    );
+  });
+
+  it("generates warning and increments errored for items missing idField", () => {
+    const payload = {
+      officers: [{ level: 50, rank: "Captain" }], // no 'id'
+      ships: [],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    expect(result.stats.officers.errored).toBe(1);
+    expect(result.warnings.some((w) => w.includes("missing idField"))).toBe(true);
+  });
+
+  it("returns success=false and data=null for non-object payload", () => {
+    const result = translate(BASE_CONFIG, "not-an-object");
+    expect(result.success).toBe(false);
+    expect(result.data).toBeNull();
+    expect(result.warnings).toContain("payload must be a non-null object");
+  });
+
+  it("returns success=false and data=null for null payload", () => {
+    const result = translate(BASE_CONFIG, null);
+    expect(result.success).toBe(false);
+    expect(result.data).toBeNull();
+  });
+
+  it("returns success=false and data=null for array payload", () => {
+    const result = translate(BASE_CONFIG, [1, 2, 3]);
+    expect(result.success).toBe(false);
+    expect(result.data).toBeNull();
+  });
+
+  it("returns success=false when no entities are translated (empty arrays)", () => {
+    const payload = { officers: [], ships: [] };
+    const result = translate(BASE_CONFIG, payload);
+    expect(result.success).toBe(false);
+    expect(result.warnings).toContain("no entities were successfully translated");
+  });
+
+  it("applies defaults for missing fields", () => {
+    const payload = {
+      officers: [{ id: "kirk", level: "50", rank: "Captain" }],
+      ships: [],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    // The 'owned' default should be applied
+    const officer = result.data!.officers![0] as Record<string, unknown>;
+    expect(officer.owned).toBe(true);
+  });
+
+  it("applies transforms correctly (toNumber on level)", () => {
+    const payload = {
+      officers: [{ id: "kirk", level: "50", rank: "Captain", power: 9000 }],
+      ships: [],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    // level was "50" string → should be 50 number via toNumber transform
+    expect(result.data!.officers![0].level).toBe(50);
+  });
+
+  it("translates docks with shipIdPrefix", () => {
+    const config: TranslatorConfig = {
+      name: "Dock Test",
+      version: "1.0",
+      sourceType: "test-docks",
+      docks: {
+        sourcePath: "docks",
+        fieldMap: {
+          slot: "number",
+          ship_id: "shipId",
+        },
+        shipIdPrefix: "cdn:ship:",
+        transforms: {
+          number: { type: "toNumber" },
+        },
+      },
+    };
+
+    const payload = {
+      docks: [
+        { slot: "1", ship_id: "enterprise" },
+        { slot: "2", ship_id: "reliant" },
+      ],
+    };
+
+    const result = translate(config, payload);
+    expect(result.success).toBe(true);
+    expect(result.data!.docks).toHaveLength(2);
+    expect(result.data!.docks![0].shipId).toBe("cdn:ship:enterprise");
+    expect(result.data!.docks![0].number).toBe(1);
+    expect(result.data!.docks![1].shipId).toBe("cdn:ship:reliant");
+    expect(result.stats.docks.translated).toBe(2);
+  });
+
+  it("translates docks without shipIdPrefix", () => {
+    const config: TranslatorConfig = {
+      name: "Dock Test No Prefix",
+      version: "1.0",
+      sourceType: "test-docks",
+      docks: {
+        sourcePath: "docks",
+        fieldMap: { ship_id: "shipId" },
+      },
+    };
+
+    const payload = { docks: [{ ship_id: "enterprise" }] };
+    const result = translate(config, payload);
+    expect(result.data!.docks![0].shipId).toBe("enterprise");
+  });
+
+  it("skips non-object items in entity arrays with errored count", () => {
+    const payload = {
+      officers: [null, "bad", { id: "kirk", level: "50" }],
+      ships: [],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    expect(result.stats.officers.errored).toBe(2);
+    expect(result.stats.officers.translated).toBe(1);
+    expect(result.warnings.some((w) => w.includes("not a valid object"))).toBe(true);
+  });
+
+  it("includes exportDate in output data", () => {
+    const payload = {
+      officers: [{ id: "kirk", level: 50 }],
+      ships: [],
+    };
+
+    const result = translate(BASE_CONFIG, payload);
+    expect(result.data!.exportDate).toBeDefined();
+    // Should be a valid ISO date string
+    expect(new Date(result.data!.exportDate!).toISOString()).toBe(result.data!.exportDate);
+  });
+});


### PR DESCRIPTION
## External Overlay Translator — Config-Driven Data Import

Closes #78 | ADR-028 Cross-Cutting

### What

A schema-mapping layer that transforms external game data (any source) into `MajelGameExport` format for ingestion via `sync_overlay`. Adding a new external source requires only a new `.translator.json` config file — no code changes.

### Architecture

```
External JSON → TranslatorConfig → translate() → MajelGameExport → sync_overlay
```

- **Config-only integration**: field mapping, defaults, transforms defined in JSON
- **Source-agnostic**: translator doesn't know or care where data came from
- **Validation downstream**: translator maps faithfully; `sync_overlay` validates

### New Files

| File | Purpose |
|------|---------|
| `schemas/translator-config.schema.json` | JSON Schema (Draft 2020-12) for translator configs |
| `src/server/services/translator/types.ts` | TypeScript interfaces: TranslatorConfig, EntityMapping, DockMapping, FieldTransform, TranslationResult |
| `src/server/services/translator/translate.ts` | Core engine: `translate()`, `loadTranslatorConfig()`, `listTranslatorConfigs()`, `resolveSourcePath()`, `applyTransform()` |
| `src/server/services/translator/index.ts` | Barrel re-export |
| `src/server/routes/translator.ts` | API: GET configs, POST preview, POST apply |
| `data/translators/stfc-command-center-v1.translator.json` | STFC Command Center translator config |
| `test/translator.test.ts` | 40 unit tests |
| `test/translator-routes.test.ts` | 11 route integration tests |

### API Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/translate/configs` | List available translator configs |
| POST | `/api/translate/preview` | Translate without applying (dry-run) |
| POST | `/api/translate/apply` | Translate + pipe to `sync_overlay` |

### Transform Types

- `lookup` — Map discrete values via a table
- `toString` / `toNumber` / `toBoolean` — Type coercion

### Validation

- 1,458 tests passing (51 new) across 46 files
- TypeScript clean (`tsc --noEmit`)
- Lint clean
- Path traversal protection on config names