### PR TITLE
Add endpoint-level rate caps for import analyze/parse

### DIFF
--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -14,6 +14,23 @@ import { log } from "./logger.js";
 
 const IS_TEST = process.env.NODE_ENV === "test" || process.env.VITEST === "true";
 
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function importLimiterKey(req: { ip?: string }, userId: unknown): string {
+  if (typeof userId === "string" && userId.trim().length > 0) return `user:${userId}`;
+  return `ip:${req.ip ?? "unknown"}`;
+}
+
+function shouldSkipImportLimiter(): boolean {
+  return IS_TEST && process.env.MAJEL_TEST_ENABLE_RATE_LIMIT !== "true";
+}
+
+const IMPORT_WINDOW_MS = 60 * 1000;
+
 /**
  * Rate limiter for auth endpoints (sign-up, sign-in, password reset).
  * 10 requests per minute per IP address.
@@ -77,6 +94,42 @@ export const globalRateLimiter = rateLimit({
     sendFail(res, "RATE_LIMITED", "Too many requests. Please slow down.", 429);
   },
   skip: () => IS_TEST,
+});
+
+export const importAnalyzeRateLimiter = rateLimit({
+  windowMs: IMPORT_WINDOW_MS,
+  max: () => parsePositiveInt(process.env.MAJEL_IMPORT_ANALYZE_RPM, 6),
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  keyGenerator: (req, res) => importLimiterKey(req, res.locals.userId),
+  handler: (req, res) => {
+    const limiterKey = importLimiterKey(req, res.locals.userId);
+    log.http.warn({ ip: req.ip, path: req.path, event: "rate_limit.hit", limiter: "import_analyze", limiterKey }, "import analyze rate limit exceeded");
+    res.setHeader("Retry-After", String(Math.ceil(IMPORT_WINDOW_MS / 1000)));
+    sendFail(res, "RATE_LIMITED", "Import analyze rate limit reached. Please retry shortly.", 429, {
+      hints: ["Retry after 60 seconds", "Reduce repeated analyze requests for the same file"],
+    });
+  },
+  skip: () => shouldSkipImportLimiter(),
+});
+
+export const importParseRateLimiter = rateLimit({
+  windowMs: IMPORT_WINDOW_MS,
+  max: () => parsePositiveInt(process.env.MAJEL_IMPORT_PARSE_RPM, 20),
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  keyGenerator: (req, res) => importLimiterKey(req, res.locals.userId),
+  handler: (req, res) => {
+    const limiterKey = importLimiterKey(req, res.locals.userId);
+    log.http.warn({ ip: req.ip, path: req.path, event: "rate_limit.hit", limiter: "import_parse", limiterKey }, "import parse rate limit exceeded");
+    res.setHeader("Retry-After", String(Math.ceil(IMPORT_WINDOW_MS / 1000)));
+    sendFail(res, "RATE_LIMITED", "Import parse rate limit reached. Please retry shortly.", 429, {
+      hints: ["Retry after 60 seconds", "Batch parse calls where possible"],
+    });
+  },
+  skip: () => shouldSkipImportLimiter(),
 });
 
 /**

--- a/src/server/routes/imports.ts
+++ b/src/server/routes/imports.ts
@@ -4,6 +4,7 @@ import { createSafeRouter } from "../safe-router.js";
 import { sendFail, sendOk, ErrorCode } from "../envelope.js";
 import { requireVisitor } from "../services/auth.js";
 import { withUserScope } from "../db.js";
+import { importAnalyzeRateLimiter, importParseRateLimiter } from "../rate-limit.js";
 import {
   analyzeImport,
   mapParsedRows,
@@ -58,7 +59,7 @@ export function createImportRoutes(appState: AppState): Router {
 
   router.use("/api/import", visitor);
 
-  router.post("/api/import/analyze", async (req, res) => {
+  router.post("/api/import/analyze", importAnalyzeRateLimiter, async (req, res) => {
     const { fileName, contentBase64, format } = req.body ?? {};
 
     if (typeof fileName !== "string" || fileName.length === 0 || fileName.length > 260) {
@@ -91,7 +92,7 @@ export function createImportRoutes(appState: AppState): Router {
     }
   });
 
-  router.post("/api/import/parse", async (req, res) => {
+  router.post("/api/import/parse", importParseRateLimiter, async (req, res) => {
     const validation = validateSourcePayload(req.body ?? {});
     if (!validation.ok) return sendFail(res, validation.code, validation.message, 400);
 

--- a/test/import-routes-data.test.ts
+++ b/test/import-routes-data.test.ts
@@ -102,6 +102,37 @@ describe("Import routes — data interactions", () => {
     expect(res.body.data.analysis.format).toBe("xlsx");
   });
 
+  it("POST /api/import/analyze enforces endpoint rate cap", async () => {
+    const prevEnable = process.env.MAJEL_TEST_ENABLE_RATE_LIMIT;
+    const prevAnalyze = process.env.MAJEL_IMPORT_ANALYZE_RPM;
+    process.env.MAJEL_TEST_ENABLE_RATE_LIMIT = "true";
+    process.env.MAJEL_IMPORT_ANALYZE_RPM = "1";
+
+    try {
+      const payload = {
+        fileName: "fleet.csv",
+        contentBase64: toBase64("Officer,Level\nKirk,20\n"),
+        format: "csv",
+      };
+
+      const first = await testRequest(app)
+        .post("/api/import/analyze")
+        .send(payload);
+      expect(first.status).toBe(200);
+
+      const second = await testRequest(app)
+        .post("/api/import/analyze")
+        .send(payload);
+      expect(second.status).toBe(429);
+      expect(second.body.error.code).toBe("RATE_LIMITED");
+    } finally {
+      if (prevEnable == null) delete process.env.MAJEL_TEST_ENABLE_RATE_LIMIT;
+      else process.env.MAJEL_TEST_ENABLE_RATE_LIMIT = prevEnable;
+      if (prevAnalyze == null) delete process.env.MAJEL_IMPORT_ANALYZE_RPM;
+      else process.env.MAJEL_IMPORT_ANALYZE_RPM = prevAnalyze;
+    }
+  });
+
   it("POST /api/import/parse parses csv payload", async () => {
     const csv = "Officer,Level\nKirk,20\n";
     const res = await testRequest(app)
@@ -116,6 +147,37 @@ describe("Import routes — data interactions", () => {
     expect(res.body.data.parsed.headers).toEqual(["Officer", "Level"]);
     expect(res.body.data.parsed.rowCount).toBe(1);
     expect(res.body.data.parsed.rows[0]).toEqual(["Kirk", "20"]);
+  });
+
+  it("POST /api/import/parse enforces endpoint rate cap", async () => {
+    const prevEnable = process.env.MAJEL_TEST_ENABLE_RATE_LIMIT;
+    const prevParse = process.env.MAJEL_IMPORT_PARSE_RPM;
+    process.env.MAJEL_TEST_ENABLE_RATE_LIMIT = "true";
+    process.env.MAJEL_IMPORT_PARSE_RPM = "1";
+
+    try {
+      const payload = {
+        fileName: "fleet.csv",
+        contentBase64: toBase64("Officer,Level\nKirk,20\n"),
+        format: "csv",
+      };
+
+      const first = await testRequest(app)
+        .post("/api/import/parse")
+        .send(payload);
+      expect(first.status).toBe(200);
+
+      const second = await testRequest(app)
+        .post("/api/import/parse")
+        .send(payload);
+      expect(second.status).toBe(429);
+      expect(second.body.error.code).toBe("RATE_LIMITED");
+    } finally {
+      if (prevEnable == null) delete process.env.MAJEL_TEST_ENABLE_RATE_LIMIT;
+      else process.env.MAJEL_TEST_ENABLE_RATE_LIMIT = prevEnable;
+      if (prevParse == null) delete process.env.MAJEL_IMPORT_PARSE_RPM;
+      else process.env.MAJEL_IMPORT_PARSE_RPM = prevParse;
+    }
   });
 
   it("POST /api/import/parse parses tsv payload", async () => {


### PR DESCRIPTION
## Summary
- add dedicated per-endpoint rate limiters for `/api/import/analyze` and `/api/import/parse`
- key by authenticated user id with IP fallback
- add Retry-After + structured 429 envelope for these routes
- add tests covering analyze/parse cap enforcement

## Validation
- npx vitest run test/import-routes-data.test.ts
- npm run typecheck

Closes #176