### PR TITLE
Add import rejection observability counters

### DIFF
--- a/src/server/routes/imports.ts
+++ b/src/server/routes/imports.ts
@@ -25,6 +25,7 @@ import {
   type OfficerOverlayRow,
   type ShipOverlayRow,
 } from "../services/route-helpers/imports-helpers.js";
+import { classifyImportRejectReason, recordImportReject } from "../services/import-rejection-counters.js";
 
 const MAX_IMPORT_ROWS = 10000;
 
@@ -63,15 +64,19 @@ export function createImportRoutes(appState: AppState): Router {
     const { fileName, contentBase64, format } = req.body ?? {};
 
     if (typeof fileName !== "string" || fileName.length === 0 || fileName.length > 260) {
+      recordImportReject("analyze", "file_name_invalid");
       return sendFail(res, ErrorCode.INVALID_PARAM, "fileName must be 1-260 characters", 400);
     }
     if (typeof contentBase64 !== "string" || contentBase64.length === 0) {
+      recordImportReject("analyze", "missing_content_base64");
       return sendFail(res, ErrorCode.MISSING_PARAM, "contentBase64 is required", 400);
     }
     if (contentBase64.length > 15_000_000) {
+      recordImportReject("analyze", "base64_too_large");
       return sendFail(res, ErrorCode.INVALID_PARAM, "contentBase64 exceeds size limit", 400);
     }
     if (format !== "csv" && format !== "tsv" && format !== "xlsx") {
+      recordImportReject("analyze", "invalid_format");
       return sendFail(res, ErrorCode.INVALID_PARAM, 'format must be one of "csv", "tsv", "xlsx"', 400);
     }
 
@@ -88,6 +93,7 @@ export function createImportRoutes(appState: AppState): Router {
       return sendOk(res, { analysis });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      recordImportReject("analyze", classifyImportRejectReason(msg));
       return sendFail(res, ErrorCode.INVALID_PARAM, `Import analysis failed: ${msg}`, 400);
     }
   });
@@ -101,6 +107,7 @@ export function createImportRoutes(appState: AppState): Router {
       return sendOk(res, { parsed });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      recordImportReject("parse", classifyImportRejectReason(msg));
       return sendFail(res, ErrorCode.INVALID_PARAM, `Import parse failed: ${msg}`, 400);
     }
   });

--- a/src/server/services/import-rejection-counters.ts
+++ b/src/server/services/import-rejection-counters.ts
@@ -1,0 +1,56 @@
+export type ImportRejectEndpoint = "analyze" | "parse";
+
+export type ImportRejectReason =
+  | "file_name_invalid"
+  | "missing_content_base64"
+  | "base64_too_large"
+  | "invalid_base64"
+  | "decoded_too_large"
+  | "invalid_format"
+  | "format_mismatch"
+  | "parse_safety_rows"
+  | "parse_safety_columns"
+  | "parse_safety_cell"
+  | "parse_failed_other";
+
+interface ImportRejectCounterRecord {
+  endpoint: ImportRejectEndpoint;
+  reason: ImportRejectReason;
+  count: number;
+}
+
+const counters = new Map<string, number>();
+
+export function recordImportReject(endpoint: ImportRejectEndpoint, reason: ImportRejectReason): void {
+  const key = `${endpoint}:${reason}`;
+  counters.set(key, (counters.get(key) ?? 0) + 1);
+}
+
+export function listImportRejectCounters(): ImportRejectCounterRecord[] {
+  return [...counters.entries()]
+    .map(([key, count]) => {
+      const [endpoint, reason] = key.split(":") as [ImportRejectEndpoint, ImportRejectReason];
+      return { endpoint, reason, count };
+    })
+    .sort((a, b) => (a.endpoint === b.endpoint
+      ? a.reason.localeCompare(b.reason)
+      : a.endpoint.localeCompare(b.endpoint)));
+}
+
+export function resetImportRejectCounters(): void {
+  counters.clear();
+}
+
+export function classifyImportRejectReason(message: string): ImportRejectReason {
+  if (message.includes("must be 1-260 characters")) return "file_name_invalid";
+  if (message.includes("contentBase64 is required")) return "missing_content_base64";
+  if (message.includes("contentBase64 exceeds size limit")) return "base64_too_large";
+  if (message.includes("valid base64")) return "invalid_base64";
+  if (message.includes("decoded import payload exceeds size limit")) return "decoded_too_large";
+  if (message.includes("format must be one of")) return "invalid_format";
+  if (message.includes("does not match declared format")) return "format_mismatch";
+  if (message.includes("maximum rows")) return "parse_safety_rows";
+  if (message.includes("maximum columns")) return "parse_safety_columns";
+  if (message.includes("maximum length")) return "parse_safety_cell";
+  return "parse_failed_other";
+}

--- a/src/server/services/route-helpers/imports-helpers.ts
+++ b/src/server/services/route-helpers/imports-helpers.ts
@@ -1,6 +1,7 @@
 import { ErrorCode } from "../../envelope.js";
 import type { OwnershipState } from "../../stores/overlay-store.js";
 import type { ImportFormat } from "../import-mapping.js";
+import { recordImportReject } from "../import-rejection-counters.js";
 
 const BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 const MAX_IMPORT_BASE64_CHARS = 15_000_000;
@@ -28,23 +29,29 @@ export function validateSourcePayload(payload: Record<string, unknown>):
   const { fileName, contentBase64, format } = payload;
 
   if (typeof fileName !== "string" || fileName.length === 0 || fileName.length > 260) {
+    recordImportReject("parse", "file_name_invalid");
     return { ok: false, code: ErrorCode.INVALID_PARAM, message: "fileName must be 1-260 characters" };
   }
   if (typeof contentBase64 !== "string" || contentBase64.length === 0) {
+    recordImportReject("parse", "missing_content_base64");
     return { ok: false, code: ErrorCode.MISSING_PARAM, message: "contentBase64 is required" };
   }
   if (contentBase64.length > MAX_IMPORT_BASE64_CHARS) {
+    recordImportReject("parse", "base64_too_large");
     return { ok: false, code: ErrorCode.INVALID_PARAM, message: "contentBase64 exceeds size limit" };
   }
   if (!BASE64_RE.test(contentBase64)) {
+    recordImportReject("parse", "invalid_base64");
     return { ok: false, code: ErrorCode.INVALID_PARAM, message: "contentBase64 must be valid base64" };
   }
   const decodedBytes = Math.floor((contentBase64.length * 3) / 4)
     - (contentBase64.endsWith("==") ? 2 : contentBase64.endsWith("=") ? 1 : 0);
   if (decodedBytes > MAX_IMPORT_DECODED_BYTES) {
+    recordImportReject("parse", "decoded_too_large");
     return { ok: false, code: ErrorCode.INVALID_PARAM, message: "decoded import payload exceeds size limit" };
   }
   if (format !== "csv" && format !== "tsv" && format !== "xlsx") {
+    recordImportReject("parse", "invalid_format");
     return { ok: false, code: ErrorCode.INVALID_PARAM, message: 'format must be one of "csv", "tsv", "xlsx"' };
   }
 

--- a/test/import-routes-data.test.ts
+++ b/test/import-routes-data.test.ts
@@ -13,6 +13,7 @@ import {
   BASE_IMPORT_MAP_PAYLOAD_CASES,
   baseImportParsePayloadCases,
 } from "./helpers/data-route-base.js";
+import { listImportRejectCounters, resetImportRejectCounters } from "../src/server/services/import-rejection-counters.js";
 
 const REF_DEFAULTS = {
   source: "test",
@@ -40,6 +41,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  resetImportRejectCounters();
   await truncatePublicTables(pool);
   app = createApp(
     makeState({
@@ -240,6 +242,11 @@ describe("Import routes — data interactions", () => {
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe("INVALID_PARAM");
     expect(res.body.error.message).toContain("does not match declared format csv");
+    expect(listImportRejectCounters()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ endpoint: "parse", reason: "format_mismatch", count: 1 }),
+      ]),
+    );
   });
 
   it("POST /api/import/parse rejects text payload declared as xlsx", async () => {
@@ -280,6 +287,11 @@ describe("Import routes — data interactions", () => {
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe("INVALID_PARAM");
     expect(res.body.error.message).toContain("valid base64");
+    expect(listImportRejectCounters()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ endpoint: "parse", reason: "invalid_base64", count: 1 }),
+      ]),
+    );
   });
 
   it("POST /api/import/parse rejects oversized row counts", async () => {
@@ -298,6 +310,36 @@ describe("Import routes — data interactions", () => {
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe("INVALID_PARAM");
     expect(res.body.error.message).toContain("maximum rows");
+    expect(listImportRejectCounters()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ endpoint: "parse", reason: "parse_safety_rows", count: 1 }),
+      ]),
+    );
+  });
+
+  it("POST /api/import/analyze records format-mismatch rejection", async () => {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("First");
+    sheet.addRow(["Officer", "Level"]);
+    sheet.addRow(["Kirk", "20"]);
+    const xlsxBuffer = await workbook.xlsx.writeBuffer();
+
+    const res = await testRequest(app)
+      .post("/api/import/analyze")
+      .send({
+        fileName: "fleet.csv",
+        contentBase64: Buffer.from(xlsxBuffer).toString("base64"),
+        format: "csv",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PARAM");
+    expect(res.body.error.message).toContain("does not match declared format csv");
+    expect(listImportRejectCounters()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ endpoint: "analyze", reason: "format_mismatch", count: 1 }),
+      ]),
+    );
   });
 
   it("POST /api/import/map maps typed fields from parsed rows", async () => {


### PR DESCRIPTION
## Summary
- add in-memory counters for import rejection events by endpoint (`analyze`/`parse`) and reason
- classify rejection reasons (invalid base64, format mismatch, parse safety limits, etc.)
- increment counters on import analyze/parse validation and parsing failures
- add regression tests validating counter increments for representative reject paths

## Validation
- npx vitest run test/import-routes-data.test.ts
- npx tsc --noEmit

Closes #178